### PR TITLE
Add category to library.properties

### DIFF
--- a/Unorthodox/library.properties
+++ b/Unorthodox/library.properties
@@ -3,6 +3,7 @@ author=Jeremy
 email=unorthodox.engineers@gmail.com
 sentence=Libraries
 paragraph=Droid<br/>JournalFS<br/>Prefix Trees<br/>Microparser 'Cursors'<br/>Red-Black Binary Trees<br/>Hal Queues
+category=Other
 url=
 architectures=avr
 version=1.0


### PR DESCRIPTION
Lack of a category field in library.properties causes the warning:
```
WARNING: Category '' in library Unorthodox is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format